### PR TITLE
fix: plugin check update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v3
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
         with:
           command: svn --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
+        uses: asdf-vm/actions/plugin-test@1117842ea70e2711a0072e3a71265cbfe2c830be
         with:
           command: svn --version


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a specific commit of the `asdf-vm/actions/install` action instead of the `plugin-test` action.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R20): Replaced `asdf-vm/actions/plugin-test@v3` with `asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be` to ensure a specific version of the action is used.