### PR TITLE
Fix CI: add checkout step before plugin test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
       - name: Install SVN build dependencies
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then


### PR DESCRIPTION
## Summary
Fixes the 'Remote branch not found' error in CI by adding explicit repository checkout before running the asdf plugin test.

## Problem
The asdf-vm/actions/plugin-test@v4 action was failing with:
```
FAILED: svn was not properly installed reason: unable to clone plugin: fatal: Remote branch [commit-sha] not found in upstream origin
```

## Solution
Added `actions/checkout@v4` step before the plugin test to ensure the repository is properly checked out and available to the action.

## Changes
- Add `actions/checkout@v4` step at the beginning of the job
- Keep using `asdf-vm/actions/plugin-test@v4` (latest version)
- Maintain all existing dependency installation and environment setup

This is a minimal fix that should resolve the CI issue without changing the core testing approach.

🤖 Generated with [Claude Code](https://claude.ai/code)