### PR TITLE
Fix CI: replace broken plugin-test action with manual implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,33 @@ jobs:
             brew install autoconf automake libtool pkg-config openssl sqlite apr apr-util
           fi
 
-      - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v4
-        with:
-          command: svn --version
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@v3
+        
+      - name: Test plugin installation and functionality
         env:
-          # Skip complex dependency checking in CI for now
           ASDF_SVN_SKIP_DEPS_CHECK: "true"
+        run: |
+          # Add plugin from local directory
+          asdf plugin add svn "${{ github.workspace }}"
+          
+          # Test list-all command
+          echo "Testing asdf list-all svn..."
+          available_versions=$(asdf list-all svn | head -5)
+          echo "Available versions:"
+          echo "$available_versions"
+          
+          # Get latest version for testing
+          latest_version=$(asdf list-all svn | tail -1)
+          echo "Latest version: $latest_version"
+          
+          # Install the latest version
+          echo "Installing SVN version: $latest_version"
+          asdf install svn "$latest_version"
+          
+          # Set it as global
+          asdf global svn "$latest_version"
+          
+          # Test that SVN works
+          echo "Testing svn --version:"
+          svn --version


### PR DESCRIPTION
## Summary
Replaces the broken `asdf-vm/actions/plugin-test@v4` action with a working manual implementation.

## Problem Analysis
The `asdf-vm/actions/plugin-test@v4` action consistently fails with:
```
FAILED: svn was not properly installed reason: unable to clone plugin: 
fatal: Remote branch [commit-sha] not found in upstream origin
```

This happens even when:
- The commit SHA exists and is valid
- Repository is properly checked out
- All dependencies are installed correctly

This appears to be a bug in the action itself where it cannot properly resolve commit references.

## Solution
Implemented a manual test that provides the same coverage:

1. **Setup**: Uses `asdf-vm/actions/setup@v3` to install asdf
2. **Plugin Installation**: Adds plugin from local workspace (`github.workspace`)
3. **Version Listing**: Tests `asdf list-all svn` functionality
4. **Installation**: Installs latest available SVN version  
5. **Verification**: Tests `svn --version` command works

## Benefits
- ✅ Eliminates the broken action dependency
- ✅ Provides same test coverage as the original action
- ✅ Uses local code directly (no git cloning issues)
- ✅ More transparent - we can see exactly what's being tested
- ✅ Easier to debug if issues arise

## Testing
This manual approach tests the complete user workflow:
- Plugin installation from local source
- Version discovery and selection
- SVN compilation and installation
- Command functionality verification

🤖 Generated with [Claude Code](https://claude.ai/code)